### PR TITLE
feat: Integrate Prometheus, Grafana, and Loki monitoring stack

### DIFF
--- a/genai/app/main.py
+++ b/genai/app/main.py
@@ -1,8 +1,9 @@
 import logging
 from fastapi import FastAPI
 from contextlib import asynccontextmanager
+from prometheus_fastapi_instrumentator import Instrumentator
 
-from app.api.api_router import api_router  # Corrected import
+from app.api.api_router import api_router
 from app.config import settings
 from app.utils.logging_config import (
     setup_logging,
@@ -33,6 +34,8 @@ app = FastAPI(
     description="AI Service for StudySync: AI-Powered Collaborative Study Assistant",
     lifespan=lifespan,
 )
+
+Instrumentator().instrument(app).expose(app)
 
 app.include_router(api_router, prefix="/api/v1")
 

--- a/genai/k8s/01-genai-app-deployment.yaml
+++ b/genai/k8s/01-genai-app-deployment.yaml
@@ -14,10 +14,15 @@ spec:
     metadata:
       labels:
         app: genai-app
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/path: "/metrics"
+        prometheus.io/port: "8000"
     spec:
       containers:
       - name: genai-app
-        image: ghcr.io/aet-devops25/team-cache-me-if-you-can/genai-app:21c12f9c57cb558b7932242c996fad51af441f2d@sha256:7d0a1848cd3d0e144a3efb92efbcf8bbbbca1a967d143eaf838023fa29ca5a90
+        image: ghcr.io/aet-devops25/team-cache-me-if-you-can/genai-app:latest
+        imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8000
         env:
@@ -28,5 +33,3 @@ spec:
             secretKeyRef:
               name: openai-credentials
               key: OPENAI_API_KEY
-        # If you have other env vars from .env for the app, add them here
-        # either directly, from a ConfigMap, or from the same/another Secret. 

--- a/genai/k8s/monitoring/grafana-datasources.yaml
+++ b/genai/k8s/monitoring/grafana-datasources.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-datasources
+  namespace: cache-me-if-you-can-genai
+data:
+  datasources.yaml: |
+    apiVersion: 1
+    datasources:
+    - name: Prometheus
+      type: prometheus
+      access: proxy
+      url: http://prometheus-service:9090
+      isDefault: true
+    - name: Loki
+      type: loki
+      access: proxy
+      url: http://loki-service:3100 

--- a/genai/k8s/monitoring/grafana-deployment.yaml
+++ b/genai/k8s/monitoring/grafana-deployment.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grafana-deployment
+  namespace: cache-me-if-you-can-genai
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: grafana
+  template:
+    metadata:
+      labels:
+        app: grafana
+    spec:
+      containers:
+        - name: grafana
+          image: grafana/grafana:9.4.7
+          ports:
+            - containerPort: 3000
+          volumeMounts:
+            - name: grafana-datasources-volume
+              mountPath: /etc/grafana/provisioning/datasources
+      volumes:
+        - name: grafana-datasources-volume
+          configMap:
+            name: grafana-datasources 

--- a/genai/k8s/monitoring/grafana-ingress.yaml
+++ b/genai/k8s/monitoring/grafana-ingress.yaml
@@ -1,0 +1,20 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: grafana-ingress
+  namespace: cache-me-if-you-can-genai
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: cache-me-if-you-can-genai.student.k8s.aet.cit.tum.de
+    http:
+      paths:
+      - path: /grafana(/|$)(.*)
+        pathType: Prefix
+        backend:
+          service:
+            name: grafana-service
+            port:
+              number: 3000 

--- a/genai/k8s/monitoring/grafana-service.yaml
+++ b/genai/k8s/monitoring/grafana-service.yaml
@@ -1,13 +1,13 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: genai-app-service
+  name: grafana-service
   namespace: cache-me-if-you-can-genai
 spec:
   selector:
-    app: genai-app
+    app: grafana
   ports:
     - protocol: TCP
-      port: 8000
-      targetPort: 8000
-  type: ClusterIP
+      port: 3000
+      targetPort: 3000
+  type: ClusterIP 

--- a/genai/k8s/monitoring/loki-configmap.yaml
+++ b/genai/k8s/monitoring/loki-configmap.yaml
@@ -1,0 +1,54 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: loki-config
+  namespace: cache-me-if-you-can-genai
+data:
+  loki-config.yaml: |
+    auth_enabled: false
+
+    server:
+      http_listen_port: 3100
+
+    ingester:
+      lifecycler:
+        address: 127.0.0.1
+        ring:
+          kvstore:
+            store: inmemory
+          replication_factor: 1
+      chunk_idle_period: 5m
+      chunk_target_size: 1048576
+      chunk_retain_period: 1m
+      max_transfer_retries: 0
+      wal:
+        enabled: true
+        dir: /loki/wal
+
+    schema_config:
+      configs:
+        - from: 2020-10-24
+          store: boltdb-shipper
+          object_store: filesystem
+          schema: v11
+          index:
+            prefix: index_
+            period: 24h
+
+    storage_config:
+      boltdb_shipper:
+        active_index_directory: /loki/boltdb-shipper-active
+        cache_location: /loki/boltdb-shipper-cache
+        cache_ttl: 24h
+        shared_store: filesystem
+      filesystem:
+        directory: /loki/chunks
+
+    compactor:
+      working_directory: /loki/compactor
+      shared_store: filesystem
+
+    limits_config:
+      enforce_metric_name: false
+      reject_old_samples: true
+      reject_old_samples_max_age: 168h 

--- a/genai/k8s/monitoring/loki-deployment.yaml
+++ b/genai/k8s/monitoring/loki-deployment.yaml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: loki-deployment
+  namespace: cache-me-if-you-can-genai
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: loki
+  template:
+    metadata:
+      labels:
+        app: loki
+    spec:
+      containers:
+        - name: loki
+          image: grafana/loki:2.9.0
+          args:
+            - "-config.file=/etc/loki/loki-config.yaml"
+          ports:
+            - containerPort: 3100
+          volumeMounts:
+            - name: loki-config-volume
+              mountPath: /etc/loki/
+            - name: loki-storage-volume
+              mountPath: /loki
+      volumes:
+        - name: loki-config-volume
+          configMap:
+            name: loki-config
+        - name: loki-storage-volume
+          emptyDir: {} 

--- a/genai/k8s/monitoring/loki-service.yaml
+++ b/genai/k8s/monitoring/loki-service.yaml
@@ -1,13 +1,13 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: genai-app-service
+  name: loki-service
   namespace: cache-me-if-you-can-genai
 spec:
   selector:
-    app: genai-app
+    app: loki
   ports:
     - protocol: TCP
-      port: 8000
-      targetPort: 8000
-  type: ClusterIP
+      port: 3100
+      targetPort: 3100
+  type: ClusterIP 

--- a/genai/k8s/monitoring/prometheus-configmap.yaml
+++ b/genai/k8s/monitoring/prometheus-configmap.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-config
+  namespace: cache-me-if-you-can-genai
+data:
+  prometheus.yml: |
+    global:
+      scrape_interval: 15s
+    scrape_configs:
+      - job_name: 'genai-app'
+        kubernetes_sd_configs:
+          - role: pod
+        relabel_configs:
+          - source_labels: [__meta_kubernetes_pod_label_app]
+            action: keep
+            regex: genai-app
+          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+            action: keep
+            regex: "true"
+          - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+            action: replace
+            target_label: __metrics_path__
+            regex: (.+)
+          - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+            action: replace
+            regex: ([^:]+)(?::\d+)?;(\d+)
+            replacement: $1:$2
+            target_label: __address__
+      - job_name: 'prometheus'
+        static_configs:
+          - targets: ['localhost:9090'] 

--- a/genai/k8s/monitoring/prometheus-deployment.yaml
+++ b/genai/k8s/monitoring/prometheus-deployment.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prometheus-deployment
+  namespace: cache-me-if-you-can-genai
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: prometheus
+  template:
+    metadata:
+      labels:
+        app: prometheus
+    spec:
+      serviceAccountName: prometheus
+      containers:
+        - name: prometheus
+          image: prom/prometheus:v2.44.0
+          args:
+            - "--config.file=/etc/prometheus/prometheus.yml"
+            - "--storage.tsdb.path=/prometheus/"
+          ports:
+            - containerPort: 9090
+          volumeMounts:
+            - name: prometheus-config-volume
+              mountPath: /etc/prometheus/
+            - name: prometheus-storage-volume
+              mountPath: /prometheus/
+      volumes:
+        - name: prometheus-config-volume
+          configMap:
+            name: prometheus-config
+        - name: prometheus-storage-volume
+          emptyDir: {} 

--- a/genai/k8s/monitoring/prometheus-rbac.yaml
+++ b/genai/k8s/monitoring/prometheus-rbac.yaml
@@ -1,0 +1,38 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prometheus
+  namespace: cache-me-if-you-can-genai
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: prometheus
+rules:
+  - apiGroups: [""]
+    resources:
+      - nodes
+      - services
+      - endpoints
+      - pods
+    verbs: ["get", "list", "watch"]
+  - apiGroups:
+      - extensions
+    resources:
+      - ingresses
+    verbs: ["get", "list", "watch"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus
+subjects:
+  - kind: ServiceAccount
+    name: prometheus
+    namespace: cache-me-if-you-can-genai 

--- a/genai/k8s/monitoring/prometheus-service.yaml
+++ b/genai/k8s/monitoring/prometheus-service.yaml
@@ -1,13 +1,13 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: genai-app-service
+  name: prometheus-service
   namespace: cache-me-if-you-can-genai
 spec:
   selector:
-    app: genai-app
+    app: prometheus
   ports:
     - protocol: TCP
-      port: 8000
-      targetPort: 8000
-  type: ClusterIP
+      port: 9090
+      targetPort: 9090
+  type: ClusterIP 

--- a/genai/k8s/monitoring/promtail-configmap.yaml
+++ b/genai/k8s/monitoring/promtail-configmap.yaml
@@ -1,0 +1,38 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: promtail-config
+  namespace: cache-me-if-you-can-genai
+data:
+  promtail-config.yaml: |
+    server:
+      http_listen_port: 9080
+      grpc_listen_port: 0
+
+    positions:
+      filename: /tmp/positions.yaml
+
+    clients:
+      - url: http://loki-service:3100/loki/api/v1/push
+
+    scrape_configs:
+      - job_name: kubernetes-pods
+        kubernetes_sd_configs:
+          - role: pod
+            namespaces:
+              names:
+                - cache-me-if-you-can-genai
+        relabel_configs:
+          - source_labels:
+              - __meta_kubernetes_pod_controller_name
+            regex: ([^;]+)
+            target_label: __service__
+          - source_labels:
+              - __meta_kubernetes_pod_name
+            target_label: pod
+          - source_labels:
+              - __meta_kubernetes_pod_node_name
+            target_label: node
+          - source_labels:
+              - __meta_kubernetes_pod_label_app
+            target_label: app 

--- a/genai/k8s/monitoring/promtail-daemonset.yaml
+++ b/genai/k8s/monitoring/promtail-daemonset.yaml
@@ -1,0 +1,43 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: promtail
+  namespace: cache-me-if-you-can-genai
+  labels:
+    app: promtail
+spec:
+  selector:
+    matchLabels:
+      app: promtail
+  template:
+    metadata:
+      labels:
+        app: promtail
+    spec:
+      serviceAccountName: promtail
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+      containers:
+        - name: promtail
+          image: grafana/promtail:2.9.0
+          args:
+            - "-config.file=/etc/promtail/promtail-config.yaml"
+          volumeMounts:
+            - name: promtail-config
+              mountPath: /etc/promtail
+            - name: varlog
+              mountPath: /var/log
+            - name: varlibdockercontainers
+              mountPath: /var/lib/docker/containers
+              readOnly: true
+      volumes:
+        - name: promtail-config
+          configMap:
+            name: promtail-config
+        - name: varlog
+          hostPath:
+            path: /var/log
+        - name: varlibdockercontainers
+          hostPath:
+            path: /var/lib/docker/containers 

--- a/genai/k8s/monitoring/promtail-rbac.yaml
+++ b/genai/k8s/monitoring/promtail-rbac.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: promtail
+  namespace: cache-me-if-you-can-genai
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: promtail
+rules:
+  - apiGroups: [""]
+    resources:
+      - nodes
+      - nodes/proxy
+      - services
+      - endpoints
+      - pods
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: promtail
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: promtail
+subjects:
+  - kind: ServiceAccount
+    name: promtail
+    namespace: cache-me-if-you-can-genai 

--- a/genai/requirements.txt
+++ b/genai/requirements.txt
@@ -33,6 +33,9 @@ python-dotenv>=1.0.0
 # Utilities
 # httpx # For making async HTTP requests if the AI service needs to call external APIs
 
+# Monitoring
+prometheus-fastapi-instrumentator
+
 # Testing
 pytest
 pytest-asyncio # For testing async code with FastAPI


### PR DESCRIPTION
This commit introduces a comprehensive monitoring and logging solution for the genai-service.

Key changes:
- Instrumented the FastAPI application using `prometheus-fastapi-instrumentator` to expose a `/metrics` endpoint for Prometheus.
- Added Kubernetes manifests to deploy Prometheus, Grafana, and a Loki/Promtail stack.
- Configured Prometheus to automatically discover and scrape metrics from the `genai-app`.
- Set up Promtail as a DaemonSet to collect logs from all pods in the namespace and forward them to Loki.
- Deployed Grafana with pre-configured datasources for Prometheus and Loki.
- Created an Ingress for Grafana to expose it at the `/grafana` path.
- Added necessary RBAC roles and bindings for Prometheus and Promtail.

All new monitoring components are deployed within the `cache-me-if-you-can-genai` namespace. This setup provides crucial observability into the application's performance and behavior.
#19 #20 #21 #33